### PR TITLE
Added pymc to the list of requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ PUQ requires the following Python modules:
 - jsonpickle
 - poster
 - pytest
+- pymc
 
 
 Install

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jsonpickle>=0.4
 matplotlib>=1.1
 sympy>=0.7.1
 poster>=0.8
+pymc>=2.3


### PR DESCRIPTION
Below is the log of the ImportError I got after a fresh install of PUQ using pip

```
In [1]: import puq
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-198b70986b69> in <module>()
----> 1 import puq

<home>/.local/lib/python2.7/site-packages/puq/__init__.py in <module>()
     10 from smolyak import Smolyak
     11 from scaling import Scaling
---> 12 from sweep import Sweep
     13 from simplesweep import SimpleSweep
     14 from psweep import PSweep

<home>/.local/lib/python2.7/site-packages/puq/sweep.py in <module>()
     20 # Can't build pymc for Windows, so no calibration
     21 if not sys.platform.startswith("win"):
---> 22     from puq.calibrate import calibrate
     23
     24 _vcache = {}

<home>/.local/lib/python2.7/site-packages/puq/calibrate.py in <module>()
      8 import numpy as np
      9 import copy
---> 10 import pymc
     11 from scipy.stats.kde import gaussian_kde
     12

ImportError: No module named pymc
```
